### PR TITLE
Add web pages for scenarios (templates and static directories)

### DIFF
--- a/templates/scenario1.html
+++ b/templates/scenario1.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Scenario 1: Release and Remediate</title>
+</head>
+<body>
+    <h1>Release and Remediate Feature</h1>
+    <button onclick="toggleFeature()">Toggle Feature</button>
+    <div id="feature-status"></div>
+
+    <script>
+        async function toggleFeature() {
+            const response = await fetch('/scenario1/feature');
+            const data = await response.json();
+            document.getElementById('feature-status').innerText = 
+                'Feature is currently: ' + (data.feature_flag ? 'Enabled ✅' : 'Disabled ❌');
+        }
+
+        window.onload = toggleFeature;
+    </script>
+</body>
+</html>

--- a/templates/scenario2.html
+++ b/templates/scenario2.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Scenario 2: Targeting Example</title>
+</head>
+<body>
+    <h1>Targeted Landing Page</h1>
+
+    <form id="target-form">
+        <input type="email" id="email" placeholder="Email" required><br>
+        <input type="text" id="region" placeholder="Region (e.g., us-east)" required><br>
+        <input type="text" id="subscription" placeholder="Subscription (e.g., premium)" required><br>
+        <button type="submit">Check Landing Page</button>
+    </form>
+
+    <div id="landing-content"></div>
+
+    <script>
+        document.getElementById('target-form').onsubmit = async (e) => {
+            e.preventDefault();
+            const email = document.getElementById('email').value;
+            const region = document.getElementById('region').value;
+            const subscription = document.getElementById('subscription').value;
+
+            const response = await fetch(`/scenario2/landing-page?email=${email}&region=${region}&subscription=${subscription}`);
+            const data = await response.json();
+
+            document.getElementById('landing-content').innerHTML = `
+                <p><strong>Content:</strong> ${data.content}</p>
+                <p><strong>Feature Flag Active:</strong> ${data.feature_flag ? 'Yes ✅' : 'No ❌'}</p>
+            `;
+        };
+    </script>
+</body>
+</html>

--- a/templates/scenario3.html
+++ b/templates/scenario3.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Scenario 3: Experimentation</title>
+</head>
+<body>
+    <h1>Experimentation Metrics</h1>
+
+    <form id="experiment-form">
+        <input type="email" id="email" placeholder="Email" required><br>
+        <input type="text" id="region" placeholder="Region (e.g., us-east)" required><br>
+        <input type="text" id="subscription" placeholder="Subscription (e.g., premium)" required><br>
+        <button type="submit">Simulate Banner Click</button>
+    </form>
+
+    <div id="experiment-result"></div>
+
+    <script>
+        document.getElementById('experiment-form').onsubmit = async (e) => {
+            e.preventDefault();
+            const email = document.getElementById('email').value;
+            const region = document.getElementById('region').value;
+            const subscription = document.getElementById('subscription').value;
+
+            const response = await fetch('/scenario3/banner-clicked', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({email, region, subscription})
+            });
+            const data = await response.json();
+
+            document.getElementById('experiment-result').innerText = 
+                'Banner click event: ' + data.status;
+        };
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This PR includes:

- New HTML pages (scenario1.html, scenario2.html, scenario3.html) under the templates directory.
- Static assets organized in a new static directory.
- Updated Flask routes in saas-app.py to serve each scenario page.

All changes align explicitly with provided LaunchDarkly scenario specifications.
